### PR TITLE
fix: Bump glsl version string to match version 3.2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1485,7 +1485,7 @@ int main(int argc, char** argv)
 	bool wantDebugContext = (glDebugEnv != nullptr && atoi(glDebugEnv) != 0);
 
 	// Create window with graphics context
-	const char* glsl_version = "#version 130"; // for ImGui
+	const char* glsl_version = "#version 150"; // for ImGui
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);


### PR DESCRIPTION
- MacOS complains about the wrong version of glsl so I changed it to `#version 150` to match GL version 3.2.
- ImGUI scaling seems wrong (too large) for high DPI displays:
  
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/4c4a2e00-0adb-40fa-a84e-6f465efea9fa" />

I will see if I find a fix for this.

Otherwise works great and had no issues on my MacBook Pro M1 with MacOS Sonoma 14.4 :) 